### PR TITLE
Implement Seaport migration for frontend

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "dependencies": {
         "@farcaster/frame-sdk": "^0.0.60",
         "@farcaster/quick-auth": "^0.0.6",
+        "@opensea/seaport-js": "^4.0.4",
         "hono": "^4.7.11",
         "mitt": "^3.0.1",
         "viem": "^2.30.6",
@@ -338,6 +339,8 @@
 
     "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
+    "@opensea/seaport-js": ["@opensea/seaport-js@4.0.4", "", { "dependencies": { "ethers": "^6.9.0", "merkletreejs": "^0.4.0" } }, "sha512-pOBgU+y1H9Bh463ZdgFshFBxnBQvEaGfoOJFDHbkvZTNLSqIOyuDmICFTQJEiPjYsS6tMQTbw2oJBtcVLFUT2g=="],
+
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.41.1", "", { "os": "android", "cpu": "arm" }, "sha512-NELNvyEWZ6R9QMkiytB4/L4zSEaBC03KIXEghptLGLZWJ6VPrL63ooZQCOnlx36aQPGhzuOMwDerC1Eb2VmrLw=="],
 
     "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.41.1", "", { "os": "android", "cpu": "arm64" }, "sha512-DXdQe1BJ6TK47ukAoZLehRHhfKnKg9BjnQYUu9gzhI8Mwa1d2fzxA1aw2JixHVl403bwp1+/o/NhhHtxWJBgEA=="],
@@ -428,6 +431,8 @@
 
     "acorn-walk": ["acorn-walk@8.3.2", "", {}, "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A=="],
 
+    "aes-js": ["aes-js@4.0.0-beta.5", "", {}, "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="],
+
     "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
@@ -468,6 +473,8 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
+    "buffer-reverse": ["buffer-reverse@1.0.1", "", {}, "sha512-M87YIUBsZ6N924W57vDwT/aOu8hw7ZgdByz6ijksLjmHJELBASmYTTlNHRgjE+pTsT9oJXGaDSgqqwfdHotDUg=="],
+
     "bufferutil": ["bufferutil@4.0.9", "", { "dependencies": { "node-gyp-build": "^4.3.0" } }, "sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
@@ -506,6 +513,8 @@
 
     "core-js-compat": ["core-js-compat@3.42.0", "", { "dependencies": { "browserslist": "^4.24.4" } }, "sha512-bQasjMfyDGyaeWKBIu33lHh9qlSR0MFE/Nmc6nMjf/iU9b3rSMdAYz1Baxrv4lPdGUsTqZudHA4jIGSJy0SWZQ=="],
 
+    "crypto-js": ["crypto-js@4.2.0", "", {}, "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="],
+
     "data-uri-to-buffer": ["data-uri-to-buffer@2.0.2", "", {}, "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA=="],
 
     "debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
@@ -537,6 +546,8 @@
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "ethers": ["ethers@6.14.3", "", { "dependencies": { "@adraffy/ens-normalize": "1.10.1", "@noble/curves": "1.2.0", "@noble/hashes": "1.3.2", "@types/node": "22.7.5", "aes-js": "4.0.0-beta.5", "tslib": "2.7.0", "ws": "8.17.1" } }, "sha512-qq7ft/oCJohoTcsNPFaXSQUm457MA5iWqkf1Mb11ujONdg7jBI6sAOrHaTi3j0CBqIGFSCeR/RMc+qwRRub7IA=="],
 
     "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
@@ -611,6 +622,8 @@
     "magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
 
     "meow": ["meow@13.2.0", "", {}, "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA=="],
+
+    "merkletreejs": ["merkletreejs@0.4.1", "", { "dependencies": { "buffer-reverse": "^1.0.1", "crypto-js": "^4.2.0", "treeify": "^1.1.0" } }, "sha512-W2VSHeGTdAnWtedee+pgGn7SHvncMdINnMeHAaXrfarSaMNLff/pm7RCr/QXYxN6XzJFgJZY+28ejO0lAosW4A=="],
 
     "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
 
@@ -738,6 +751,8 @@
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
+    "treeify": ["treeify@1.1.0", "", {}, "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A=="],
+
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
@@ -834,6 +849,18 @@
 
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "ethers/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.10.1", "", {}, "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="],
+
+    "ethers/@noble/curves": ["@noble/curves@1.2.0", "", { "dependencies": { "@noble/hashes": "1.3.2" } }, "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw=="],
+
+    "ethers/@noble/hashes": ["@noble/hashes@1.3.2", "", {}, "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="],
+
+    "ethers/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
+
+    "ethers/tslib": ["tslib@2.7.0", "", {}, "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="],
+
+    "ethers/ws": ["ws@8.17.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ=="],
+
     "jayson/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
     "jayson/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
@@ -849,6 +876,8 @@
     "wrangler/esbuild": ["esbuild@0.25.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.4", "@esbuild/android-arm": "0.25.4", "@esbuild/android-arm64": "0.25.4", "@esbuild/android-x64": "0.25.4", "@esbuild/darwin-arm64": "0.25.4", "@esbuild/darwin-x64": "0.25.4", "@esbuild/freebsd-arm64": "0.25.4", "@esbuild/freebsd-x64": "0.25.4", "@esbuild/linux-arm": "0.25.4", "@esbuild/linux-arm64": "0.25.4", "@esbuild/linux-ia32": "0.25.4", "@esbuild/linux-loong64": "0.25.4", "@esbuild/linux-mips64el": "0.25.4", "@esbuild/linux-ppc64": "0.25.4", "@esbuild/linux-riscv64": "0.25.4", "@esbuild/linux-s390x": "0.25.4", "@esbuild/linux-x64": "0.25.4", "@esbuild/netbsd-arm64": "0.25.4", "@esbuild/netbsd-x64": "0.25.4", "@esbuild/openbsd-arm64": "0.25.4", "@esbuild/openbsd-x64": "0.25.4", "@esbuild/sunos-x64": "0.25.4", "@esbuild/win32-arm64": "0.25.4", "@esbuild/win32-ia32": "0.25.4", "@esbuild/win32-x64": "0.25.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q=="],
 
     "@farcaster/frame-sdk/@farcaster/quick-auth/zod": ["zod@3.25.51", "", {}, "sha512-TQSnBldh+XSGL+opiSIq0575wvDPqu09AqWe1F7JhUMKY+M91/aGlK4MhpVNO7MgYfHcVCB1ffwAUTJzllKJqg=="],
+
+    "ethers/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
 
     "wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q=="],
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 	"dependencies": {
 		"@farcaster/frame-sdk": "^0.0.60",
 		"@farcaster/quick-auth": "^0.0.6",
+		"@opensea/seaport-js": "^4.0.4",
 		"hono": "^4.7.11",
 		"mitt": "^3.0.1",
 		"viem": "^2.30.6"

--- a/src/client/components/create-listing.js
+++ b/src/client/components/create-listing.js
@@ -71,13 +71,14 @@ export class CreateListing extends BaseElement {
       await transactionManager.checkNetwork()
       
       // Create listing on blockchain
-      console.log('Creating listing on blockchain...')
+      console.log('Creating listing on blockchain using Seaport...')
       const txHash = await transactionManager.createListing(
         nft.contract.address,
         nft.tokenId,
         parseFloat(price),
         expiryDays,
-        false // Assuming ERC721 for now, can be enhanced to detect standard
+        false, // Assuming ERC721 for now, can be enhanced to detect standard
+        true   // Always use Seaport for new listings
       )
       
       console.log('Transaction submitted:', txHash)
@@ -98,6 +99,7 @@ export class CreateListing extends BaseElement {
           tokenId: nft.tokenId,
           price: price,
           expiry: expiryDate.toISOString(),
+          contractType: 'seaport', // Always Seaport for new listings
           metadata: {
             name: nft.title,
             description: nft.description,
@@ -438,7 +440,7 @@ export class CreateListing extends BaseElement {
                   />
                   <span class="price-suffix">USDC</span>
                 </div>
-                <p class="fee-notice">A 1% platform fee will be charged on purchase</p>
+                <p class="fee-notice">A 1% platform fee will be added to the buyer's total</p>
                 ${error ? `<p class="error-message">${error}</p>` : ''}
               </div>
               

--- a/src/client/components/listing-details.js
+++ b/src/client/components/listing-details.js
@@ -168,14 +168,15 @@ export class ListingDetails extends BaseElement {
         actionBtn.textContent = 'Approving USDC...'
       }
       
-      await transactionManager.approveUSDC(listing.price)
+      await transactionManager.approveUSDC(listing.price, listing.contractType || 'nft_exchange')
 
       // Then purchase NFT
       if (actionBtn) {
         actionBtn.textContent = 'Purchasing NFT...'
       }
       
-      const purchaseTxHash = await transactionManager.buyListing(listing.blockchainListingId)
+      // Pass the full listing object for Seaport orders
+      const purchaseTxHash = await transactionManager.buyListing(listing)
 
       // Notify backend immediately about the purchase
       if (actionBtn) {
@@ -236,7 +237,9 @@ export class ListingDetails extends BaseElement {
       const listing = await response.json()
       
       // Cancel the listing on the smart contract
-      const cancelTxHash = await transactionManager.cancelListing(listing.blockchainListingId)
+      // For Seaport, we need to pass the order hash instead of listing ID
+      const listingIdOrOrderHash = listing.contractType === 'seaport' ? listing.orderHash : listing.blockchainListingId
+      const cancelTxHash = await transactionManager.cancelListing(listingIdOrOrderHash, listing.contractType || 'nft_exchange')
 
       // Notify backend immediately about the cancellation
       if (actionBtn) {

--- a/src/client/utils/contract.js
+++ b/src/client/utils/contract.js
@@ -1,10 +1,15 @@
 import { encodeFunctionData, parseAbi, decodeFunctionResult } from 'viem'
+import { SEAPORT_ADDRESS } from './seaport-config.js'
 
 // Contract addresses from environment
 export const ADDRESSES = {
   NFT_EXCHANGE: '0x06fB7424Ba65D587405b9C754Bc40dA9398B72F0',
-  USDC: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+  USDC: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+  SEAPORT: SEAPORT_ADDRESS
 }
+
+// Export for adapter compatibility
+export const NFT_EXCHANGE_ADDRESS = ADDRESSES.NFT_EXCHANGE
 
 // Helper function to make RPC calls through our proxy
 async function rpcCall(method, params = []) {

--- a/src/client/utils/marketplace-adapter.js
+++ b/src/client/utils/marketplace-adapter.js
@@ -1,0 +1,297 @@
+import { Seaport } from '@opensea/seaport-js'
+import { createWalletClient, custom, parseUnits, formatUnits } from 'viem'
+import { base } from 'viem/chains'
+import { 
+  SEAPORT_ADDRESS, 
+  USDC_ADDRESS, 
+  FEE_RECIPIENT,
+  FEE_BASIS_POINTS,
+  ItemType,
+  OrderType,
+  calculateFeeAmounts 
+} from './seaport-config.js'
+import { NFT_EXCHANGE_ADDRESS, NFT_EXCHANGE_ABI } from './contract.js'
+
+// Base marketplace adapter class
+export class MarketplaceAdapter {
+  constructor(signer, account) {
+    this.signer = signer
+    this.account = account
+  }
+
+  async createListing(nft, price, duration) {
+    throw new Error('Not implemented')
+  }
+
+  async buyListing(listing) {
+    throw new Error('Not implemented')
+  }
+
+  async cancelListing(listingId) {
+    throw new Error('Not implemented')
+  }
+
+  async makeOffer(nft, amount) {
+    throw new Error('Not implemented')
+  }
+
+  async acceptOffer(offerId) {
+    throw new Error('Not implemented')
+  }
+}
+
+// Adapter for existing NFTExchange contract
+export class NFTExchangeAdapter extends MarketplaceAdapter {
+  constructor(signer, account, publicClient) {
+    super(signer, account)
+    this.publicClient = publicClient
+  }
+
+  async createListing(nft, price, duration) {
+    const priceInWei = parseUnits(price.toString(), 6) // USDC has 6 decimals
+    
+    const { request } = await this.publicClient.simulateContract({
+      address: NFT_EXCHANGE_ADDRESS,
+      abi: NFT_EXCHANGE_ABI,
+      functionName: 'createListing',
+      args: [nft.contract, BigInt(nft.tokenId), priceInWei, BigInt(duration)],
+      account: this.account
+    })
+
+    const hash = await this.signer.writeContract(request)
+    return { hash, contractType: 'nftexchange' }
+  }
+
+  async buyListing(listing) {
+    const { request } = await this.publicClient.simulateContract({
+      address: NFT_EXCHANGE_ADDRESS,
+      abi: NFT_EXCHANGE_ABI,
+      functionName: 'buyListing',
+      args: [BigInt(listing.listingId)],
+      account: this.account
+    })
+
+    const hash = await this.signer.writeContract(request)
+    return { hash }
+  }
+
+  async cancelListing(listingId) {
+    const { request } = await this.publicClient.simulateContract({
+      address: NFT_EXCHANGE_ADDRESS,
+      abi: NFT_EXCHANGE_ABI,
+      functionName: 'cancelListing',
+      args: [BigInt(listingId)],
+      account: this.account
+    })
+
+    const hash = await this.signer.writeContract(request)
+    return { hash }
+  }
+
+  async makeOffer(nft, amount) {
+    const amountInWei = parseUnits(amount.toString(), 6)
+    
+    const { request } = await this.publicClient.simulateContract({
+      address: NFT_EXCHANGE_ADDRESS,
+      abi: NFT_EXCHANGE_ABI,
+      functionName: 'makeOffer',
+      args: [nft.contract, BigInt(nft.tokenId), amountInWei],
+      account: this.account
+    })
+
+    const hash = await this.signer.writeContract(request)
+    return { hash }
+  }
+
+  async acceptOffer(offerId) {
+    const { request } = await this.publicClient.simulateContract({
+      address: NFT_EXCHANGE_ADDRESS,
+      abi: NFT_EXCHANGE_ABI,
+      functionName: 'acceptOffer',
+      args: [BigInt(offerId)],
+      account: this.account
+    })
+
+    const hash = await this.signer.writeContract(request)
+    return { hash }
+  }
+}
+
+// Adapter for Seaport protocol
+export class SeaportAdapter extends MarketplaceAdapter {
+  constructor(signer, account, publicClient) {
+    super(signer, account)
+    this.publicClient = publicClient
+    
+    // Create ethers provider wrapper for Seaport SDK
+    const provider = {
+      getNetwork: async () => ({ chainId: base.id }),
+      getSigner: () => ({
+        getAddress: async () => account,
+        signMessage: async (message) => {
+          return await signer.signMessage({ message, account })
+        },
+        _signTypedData: async (domain, types, value) => {
+          return await signer.signTypedData({
+            domain,
+            types,
+            primaryType: Object.keys(types).find(t => t !== 'EIP712Domain'),
+            message: value,
+            account
+          })
+        },
+        sendTransaction: async (tx) => {
+          const hash = await signer.sendTransaction(tx)
+          return { hash, wait: async () => ({ status: 1 }) }
+        }
+      })
+    }
+
+    this.seaport = new Seaport(provider, {
+      overrides: { contractAddress: SEAPORT_ADDRESS }
+    })
+  }
+
+  async createListing(nft, price, duration) {
+    const priceInWei = parseUnits(price.toString(), 6)
+    const { sellerAmount, feeAmount } = calculateFeeAmounts(priceInWei.toString())
+    
+    const endTime = Math.floor(Date.now() / 1000) + duration
+
+    const order = {
+      offer: [{
+        itemType: nft.isERC721 ? ItemType.ERC721 : ItemType.ERC1155,
+        token: nft.contract,
+        identifier: nft.tokenId.toString(),
+        amount: "1"
+      }],
+      consideration: [
+        {
+          itemType: ItemType.ERC20,
+          token: USDC_ADDRESS,
+          amount: sellerAmount,
+          recipient: this.account
+        },
+        {
+          itemType: ItemType.ERC20,
+          token: USDC_ADDRESS,
+          amount: feeAmount,
+          recipient: FEE_RECIPIENT
+        }
+      ],
+      endTime,
+      orderType: OrderType.FULL_OPEN,
+      zone: '0x0000000000000000000000000000000000000000',
+      zoneHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      conduitKey: '0x0000000000000000000000000000000000000000000000000000000000000000'
+    }
+
+    try {
+      const { executeAllActions } = await this.seaport.createOrder(
+        order,
+        this.account
+      )
+      
+      const response = await executeAllActions()
+      
+      // Extract order hash from the response
+      const orderHash = response.orderHash || response.hash
+      
+      return { 
+        hash: orderHash, 
+        contractType: 'seaport',
+        order: response.order || order
+      }
+    } catch (error) {
+      console.error('Error creating Seaport order:', error)
+      throw error
+    }
+  }
+
+  async buyListing(listing) {
+    try {
+      const { executeAllActions } = await this.seaport.fulfillOrder({
+        order: listing.orderData,
+        accountAddress: this.account
+      })
+
+      const response = await executeAllActions()
+      return { hash: response.hash }
+    } catch (error) {
+      console.error('Error fulfilling Seaport order:', error)
+      throw error
+    }
+  }
+
+  async cancelListing(orderHash) {
+    try {
+      const tx = await this.seaport.cancelOrders([orderHash], this.account)
+      const response = await tx.wait()
+      return { hash: response.transactionHash }
+    } catch (error) {
+      console.error('Error cancelling Seaport order:', error)
+      throw error
+    }
+  }
+
+  async makeOffer(nft, amount) {
+    const amountInWei = parseUnits(amount.toString(), 6)
+    const { sellerAmount, feeAmount } = calculateFeeAmounts(amountInWei.toString())
+    
+    const endTime = Math.floor(Date.now() / 1000) + (30 * 24 * 60 * 60) // 30 days
+
+    const order = {
+      offer: [{
+        itemType: ItemType.ERC20,
+        token: USDC_ADDRESS,
+        amount: amountInWei.toString()
+      }],
+      consideration: [
+        {
+          itemType: nft.isERC721 ? ItemType.ERC721 : ItemType.ERC1155,
+          token: nft.contract,
+          identifier: nft.tokenId.toString(),
+          amount: "1",
+          recipient: this.account
+        },
+        {
+          itemType: ItemType.ERC20,
+          token: USDC_ADDRESS,
+          amount: feeAmount,
+          recipient: FEE_RECIPIENT
+        }
+      ],
+      endTime,
+      orderType: OrderType.FULL_OPEN
+    }
+
+    try {
+      const { executeAllActions } = await this.seaport.createOrder(
+        order,
+        this.account
+      )
+      
+      const response = await executeAllActions()
+      return { 
+        hash: response.orderHash || response.hash,
+        contractType: 'seaport'
+      }
+    } catch (error) {
+      console.error('Error creating Seaport offer:', error)
+      throw error
+    }
+  }
+
+  async acceptOffer(offer) {
+    return this.buyListing(offer) // Offers are just reverse listings in Seaport
+  }
+}
+
+// Factory function to create appropriate adapter
+export function getMarketplaceAdapter(contractType, signer, account, publicClient) {
+  if (contractType === 'seaport') {
+    return new SeaportAdapter(signer, account, publicClient)
+  }
+  
+  return new NFTExchangeAdapter(signer, account, publicClient)
+}

--- a/src/client/utils/seaport-config.js
+++ b/src/client/utils/seaport-config.js
@@ -1,0 +1,49 @@
+// Seaport configuration constants
+export const SEAPORT_ADDRESS = '0x0000000000000068F116a894984e2DB1123eB395'
+export const SEAPORT_VERSION = '1.6'
+
+// Seaport item types
+export const ItemType = {
+  NATIVE: 0,
+  ERC20: 1,
+  ERC721: 2,
+  ERC1155: 3,
+  ERC721_WITH_CRITERIA: 4,
+  ERC1155_WITH_CRITERIA: 5
+}
+
+// Order types
+export const OrderType = {
+  FULL_OPEN: 0,
+  PARTIAL_OPEN: 1,
+  FULL_RESTRICTED: 2,
+  PARTIAL_RESTRICTED: 3,
+  CONTRACT: 4
+}
+
+// Base USDC address
+export const USDC_ADDRESS = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+
+// Fee configuration
+export const FEE_RECIPIENT = '0x0db12C0A67bc5B8942ea3126a465d7a0b23126C7'
+export const FEE_BASIS_POINTS = 100 // 1% fee
+
+// Conduit configuration (default conduit)
+export const CONDUIT_KEY = '0x0000000000000000000000000000000000000000000000000000000000000000'
+export const CONDUIT_ADDRESS = '0x1E0049783F008A0085193E00003D00cd54003c71'
+
+// Zone configuration (no zone for basic orders)
+export const ZONE_ADDRESS = '0x0000000000000000000000000000000000000000'
+
+// Helper to calculate fee amounts
+export function calculateFeeAmounts(price) {
+  const priceInWei = BigInt(price)
+  const feeAmount = (priceInWei * BigInt(FEE_BASIS_POINTS)) / BigInt(10000)
+  const sellerAmount = priceInWei - feeAmount
+  
+  return {
+    sellerAmount: sellerAmount.toString(),
+    feeAmount: feeAmount.toString(),
+    totalAmount: priceInWei.toString()
+  }
+}

--- a/src/client/utils/transactions.js
+++ b/src/client/utils/transactions.js
@@ -1,11 +1,17 @@
 import { frameUtils } from '../components/frame-provider.js'
 import { EVENTS, emit, eventBus } from '../utils/events.js'
+import { createWalletClient, custom, createPublicClient, http } from 'viem'
+import { base } from 'viem/chains'
+import { getMarketplaceAdapter } from './marketplace-adapter.js'
+import { SEAPORT_ADDRESS, CONDUIT_ADDRESS } from './seaport-config.js'
 import { 
   ADDRESSES, 
   encodeNFTExchange, 
   encodeERC20, 
   encodeERC721,
   encodeERC1155,
+  ERC721_ABI,
+  ERC1155_ABI,
   toUSDCAmount,
   checkUSDCAllowance,
   checkUSDCBalance,
@@ -51,7 +57,27 @@ export class TransactionManager {
   }
 
   /**
-   * Send a transaction
+   * Get viem clients for blockchain interaction
+   */
+  async getViemClients() {
+    const account = await this.getWalletAddress()
+    
+    const walletClient = createWalletClient({
+      account,
+      chain: base,
+      transport: custom(this.ethProvider)
+    })
+    
+    const publicClient = createPublicClient({
+      chain: base,
+      transport: http('/api/rpc/proxy')
+    })
+    
+    return { walletClient, publicClient, account }
+  }
+
+  /**
+   * Send a transaction (legacy method for backward compatibility)
    */
   async sendTransaction(from, to, data, value = '0x0') {
     return await this.ethProvider.request({
@@ -105,120 +131,135 @@ export class TransactionManager {
     throw new Error(`Transaction ${txHash} not mined after ${maxWaitTime}ms`)
   }
 
-
   /**
-   * Create a new listing
+   * Create a new listing (defaults to Seaport)
    */
-  async createListing(nftContract, tokenId, price, durationInDays, isERC1155 = false) {
-    const userAddress = await this.getWalletAddress()
-    const priceInUSDC = toUSDCAmount(price)
-    const durationInSeconds = durationInDays * 24 * 60 * 60
-
+  async createListing(nftContract, tokenId, price, durationInDays, isERC1155 = false, useSeaport = true) {
+    const { walletClient, publicClient, account } = await this.getViemClients()
+    
     console.log('=== Starting createListing process ===')
-    console.log('User address:', userAddress)
+    console.log('User address:', account)
     console.log('NFT contract:', nftContract)
     console.log('Token ID:', tokenId)
-    console.log('NFT Exchange address:', ADDRESSES.NFT_EXCHANGE)
+    console.log('Using:', useSeaport ? 'Seaport' : 'NFTExchange')
 
     // First check if user owns the NFT
     console.log('Checking NFT ownership...')
-    const isOwner = await checkNFTOwnership(nftContract, tokenId, userAddress, isERC1155)
+    const isOwner = await checkNFTOwnership(nftContract, tokenId, account, isERC1155)
     if (!isOwner) {
       throw new Error('You do not own this NFT')
     }
     console.log('✅ Ownership confirmed')
 
-    // Check NFT approval
-    console.log('Checking current approval status...')
-    const isApproved = await checkNFTApproval(nftContract, tokenId, userAddress, isERC1155)
-    console.log('Current approval status:', isApproved)
-    
-    if (!isApproved) {
-      console.log('NFT not approved, sending approval transaction...')
-      let approveData
+    // Get the appropriate adapter
+    const adapter = getMarketplaceAdapter(
+      useSeaport ? 'seaport' : 'nftexchange',
+      walletClient,
+      account,
+      publicClient
+    )
+
+    // For Seaport, check NFT approval for conduit
+    if (useSeaport) {
+      console.log('Checking Seaport conduit approval...')
+      const approvalTarget = CONDUIT_ADDRESS
       
+      let isApproved = false
       if (isERC1155) {
-        // ERC1155 requires setApprovalForAll
-        approveData = encodeERC1155.setApprovalForAll(ADDRESSES.NFT_EXCHANGE, true)
-        console.log('Using ERC1155 setApprovalForAll')
+        const approval = await publicClient.readContract({
+          address: nftContract,
+          abi: ERC1155_ABI,
+          functionName: 'isApprovedForAll',
+          args: [account, approvalTarget]
+        })
+        isApproved = approval
       } else {
-        // For ERC721, use specific token approval
-        approveData = encodeERC721.approve(ADDRESSES.NFT_EXCHANGE, tokenId)
-        console.log('Using ERC721 approve for token:', tokenId)
+        // For ERC721, check isApprovedForAll
+        const approval = await publicClient.readContract({
+          address: nftContract,
+          abi: ERC721_ABI,
+          functionName: 'isApprovedForAll',
+          args: [account, approvalTarget]
+        })
+        isApproved = approval
       }
-      
-      console.log('Sending approval transaction...')
-      const approveTx = await this.sendTransaction(userAddress, nftContract, approveData)
-      console.log('Approval transaction hash:', approveTx)
-      
-      // Wait for approval to be mined
-      console.log('Waiting for approval transaction to be mined...')
-      const approvalReceipt = await this.waitForTransaction(approveTx)
-      console.log('Approval transaction mined! Receipt:', approvalReceipt)
-      
-      // Wait an extra second for state to propagate
-      console.log('Waiting 1 second for state propagation...')
-      await new Promise(resolve => setTimeout(resolve, 1000))
-      
-      // Double-check approval after waiting
-      console.log('Double-checking approval status...')
-      const isNowApproved = await checkNFTApproval(nftContract, tokenId, userAddress, isERC1155)
-      console.log('Approval status after waiting:', isNowApproved)
-      
-      if (!isNowApproved) {
-        throw new Error('NFT approval failed. The approval transaction was mined but the contract is still not approved.')
+
+      if (!isApproved) {
+        console.log('Approving NFT for Seaport conduit...')
+        let approveTx
+        
+        if (isERC1155) {
+          approveTx = await walletClient.writeContract({
+            address: nftContract,
+            abi: ERC1155_ABI,
+            functionName: 'setApprovalForAll',
+            args: [approvalTarget, true]
+          })
+        } else {
+          approveTx = await walletClient.writeContract({
+            address: nftContract,
+            abi: ERC721_ABI,
+            functionName: 'setApprovalForAll',
+            args: [approvalTarget, true]
+          })
+        }
+        
+        console.log('Approval transaction:', approveTx)
+        await this.waitForTransaction(approveTx)
+        console.log('✅ NFT approved for Seaport')
       }
-      console.log('✅ NFT approved successfully')
     } else {
-      console.log('✅ NFT already approved')
+      // Original NFTExchange approval logic
+      console.log('Checking current approval status...')
+      const isApproved = await checkNFTApproval(nftContract, tokenId, account, isERC1155)
+      console.log('Current approval status:', isApproved)
+      
+      if (!isApproved) {
+        console.log('NFT not approved, sending approval transaction...')
+        let approveData
+        
+        if (isERC1155) {
+          approveData = encodeERC1155.setApprovalForAll(ADDRESSES.NFT_EXCHANGE, true)
+        } else {
+          approveData = encodeERC721.approve(ADDRESSES.NFT_EXCHANGE, tokenId)
+        }
+        
+        const approveTx = await this.sendTransaction(account, nftContract, approveData)
+        console.log('Approval transaction hash:', approveTx)
+        
+        await this.waitForTransaction(approveTx)
+        console.log('✅ NFT approved successfully')
+      }
     }
 
-    // Create the listing
-    console.log('Creating listing with params:', {
-      nftContract,
-      tokenId,
-      priceInUSDC: priceInUSDC.toString(),
-      durationInSeconds,
-      userAddress
-    })
-    
+    // Create the listing through the adapter
     try {
-      const createData = encodeNFTExchange.createListing(nftContract, tokenId, priceInUSDC, durationInSeconds)
-      console.log('Encoded createListing data:', createData)
+      const result = await adapter.createListing(
+        { contract: nftContract, tokenId, isERC721: !isERC1155 },
+        price,
+        durationInDays * 24 * 60 * 60
+      )
       
-      console.log('Sending createListing transaction...')
-      const createTx = await this.sendTransaction(userAddress, ADDRESSES.NFT_EXCHANGE, createData)
-      console.log('✅ Create listing transaction sent:', createTx)
-      
-      return createTx
+      console.log('✅ Listing created:', result)
+      return result.hash
     } catch (error) {
       console.error('❌ Create listing failed:', error)
-      console.error('Full error:', JSON.stringify(error, null, 2))
-      
-      if (error.message?.includes('UnauthorizedCaller')) {
-        // Let's check the approval status one more time
-        const finalApprovalCheck = await checkNFTApproval(nftContract, tokenId, userAddress, isERC1155)
-        console.error('Final approval check:', finalApprovalCheck)
-        
-        throw new Error(`The NFT Exchange contract is not authorized to transfer your NFT. 
-          Approval status: ${finalApprovalCheck}. 
-          This might be a timing issue. Please try again in a few seconds.`)
-      }
       throw error
     }
   }
 
   /**
-   * Approve USDC spending
+   * Approve USDC spending for the appropriate contract
    */
-  async approveUSDC(amount) {
+  async approveUSDC(amount, contractType = 'seaport') {
     const userAddress = await this.getWalletAddress()
     const amountInUSDC = toUSDCAmount(amount)
+    const spenderAddress = contractType === 'seaport' ? SEAPORT_ADDRESS : ADDRESSES.NFT_EXCHANGE
     
-    console.log('Approving USDC:', amount, 'USDC')
+    console.log('Approving USDC:', amount, 'USDC for', contractType)
     
     // Check current allowance
-    const allowance = await checkUSDCAllowance(userAddress, ADDRESSES.NFT_EXCHANGE)
+    const allowance = await checkUSDCAllowance(userAddress, spenderAddress)
     
     if (allowance >= amountInUSDC) {
       console.log('USDC already approved')
@@ -226,7 +267,7 @@ export class TransactionManager {
     }
     
     // Approve USDC
-    const approveData = encodeERC20.approve(ADDRESSES.NFT_EXCHANGE, amountInUSDC)
+    const approveData = encodeERC20.approve(spenderAddress, amountInUSDC)
     const approveTx = await this.sendTransaction(userAddress, ADDRESSES.USDC, approveData)
     console.log('USDC approval tx:', approveTx)
     
@@ -237,107 +278,151 @@ export class TransactionManager {
   }
 
   /**
-   * Buy a listing
+   * Buy a listing (works for both NFTExchange and Seaport)
    */
-  async buyListing(listingId) {
-    const userAddress = await this.getWalletAddress()
+  async buyListing(listing) {
+    const { walletClient, publicClient, account } = await this.getViemClients()
     
-    console.log('Buying listing:', listingId)
+    console.log('Buying listing:', listing)
     
-    // Note: The calling code should have already approved USDC
-    // This just sends the buy transaction
-    const buyData = encodeNFTExchange.buyListing(listingId)
-    const buyTx = await this.sendTransaction(userAddress, ADDRESSES.NFT_EXCHANGE, buyData)
-    console.log('Buy listing tx:', buyTx)
+    // Determine contract type from listing
+    const contractType = listing.contractType || 'nftexchange'
+    const adapter = getMarketplaceAdapter(contractType, walletClient, account, publicClient)
+
+    // For Seaport, approve USDC if needed
+    if (contractType === 'seaport') {
+      await this.approveUSDC(listing.price, 'seaport')
+    }
     
-    return buyTx
+    const result = await adapter.buyListing(listing)
+    return result.hash
   }
 
   /**
    * Cancel a listing
    */
-  async cancelListing(listingId) {
-    const userAddress = await this.getWalletAddress()
-    const cancelData = encodeNFTExchange.cancelListing(listingId)
-    return await this.sendTransaction(userAddress, ADDRESSES.NFT_EXCHANGE, cancelData)
+  async cancelListing(listingId, contractType = 'nftexchange') {
+    const { walletClient, publicClient, account } = await this.getViemClients()
+    const adapter = getMarketplaceAdapter(contractType, walletClient, account, publicClient)
+    
+    const result = await adapter.cancelListing(listingId)
+    return result.hash
   }
 
   /**
    * Make an offer on an NFT
    */
-  async makeOffer(nftContract, tokenId, offerAmount, durationInDays) {
-    const userAddress = await this.getWalletAddress()
-    const amountInUSDC = toUSDCAmount(offerAmount)
-    const durationInSeconds = durationInDays * 24 * 60 * 60
+  async makeOffer(nftContract, tokenId, offerAmount, durationInDays, useSeaport = true) {
+    const { walletClient, publicClient, account } = await this.getViemClients()
+    const adapter = getMarketplaceAdapter(
+      useSeaport ? 'seaport' : 'nftexchange',
+      walletClient,
+      account,
+      publicClient
+    )
 
     // Check USDC balance
-    const balance = await checkUSDCBalance(userAddress)
+    const amountInUSDC = toUSDCAmount(offerAmount)
+    const balance = await checkUSDCBalance(account)
     if (balance < amountInUSDC) {
       throw new Error(`Insufficient USDC balance. You have ${Number(balance) / 1e6} USDC, need ${offerAmount} USDC`)
     }
 
-    // Check USDC allowance
-    const allowance = await checkUSDCAllowance(userAddress, ADDRESSES.NFT_EXCHANGE)
-    
-    // If allowance is insufficient, approve USDC
-    if (allowance < amountInUSDC) {
-      console.log('Approving USDC for offer...')
-      const approveData = encodeERC20.approve(ADDRESSES.NFT_EXCHANGE, amountInUSDC)
-      const approveTx = await this.sendTransaction(userAddress, ADDRESSES.USDC, approveData)
-      console.log('USDC approval tx:', approveTx)
-      
-      // Wait for approval to be mined
-      await this.waitForTransaction(approveTx)
-    }
+    // Approve USDC for the appropriate contract
+    await this.approveUSDC(offerAmount, useSeaport ? 'seaport' : 'nftexchange')
 
     // Make the offer
-    console.log('Making offer...')
-    const offerData = encodeNFTExchange.makeOffer(nftContract, tokenId, amountInUSDC, durationInSeconds)
-    const offerTx = await this.sendTransaction(userAddress, ADDRESSES.NFT_EXCHANGE, offerData)
-    console.log('Make offer tx:', offerTx)
-
-    return offerTx
+    const result = await adapter.makeOffer(
+      { contract: nftContract, tokenId },
+      offerAmount
+    )
+    
+    return result.hash
   }
 
   /**
    * Accept an offer
    */
-  async acceptOffer(offerId, nftContract, tokenId, isERC1155 = false) {
-    const userAddress = await this.getWalletAddress()
+  async acceptOffer(offer, nftContract, tokenId, isERC1155 = false) {
+    const { walletClient, publicClient, account } = await this.getViemClients()
+    const contractType = offer.contractType || 'nftexchange'
+    const adapter = getMarketplaceAdapter(contractType, walletClient, account, publicClient)
 
-    // Check NFT approval
-    const isApproved = await checkNFTApproval(nftContract, tokenId, userAddress, isERC1155)
-    
-    if (!isApproved) {
-      console.log('Approving NFT transfer for offer acceptance...')
-      let approveData
+    // For Seaport offers, we need to approve the NFT
+    if (contractType === 'seaport') {
+      const approvalTarget = CONDUIT_ADDRESS
+      let isApproved = false
+      
       if (isERC1155) {
-        approveData = encodeERC1155.setApprovalForAll(ADDRESSES.NFT_EXCHANGE, true)
+        const approval = await publicClient.readContract({
+          address: nftContract,
+          abi: ERC1155_ABI,
+          functionName: 'isApprovedForAll',
+          args: [account, approvalTarget]
+        })
+        isApproved = approval
       } else {
-        // For ERC721, approve only the specific token
-        approveData = encodeERC721.approve(ADDRESSES.NFT_EXCHANGE, tokenId)
+        const approval = await publicClient.readContract({
+          address: nftContract,
+          abi: ERC721_ABI,
+          functionName: 'isApprovedForAll',
+          args: [account, approvalTarget]
+        })
+        isApproved = approval
       }
+
+      if (!isApproved) {
+        console.log('Approving NFT for Seaport conduit...')
+        let approveTx
+        
+        if (isERC1155) {
+          approveTx = await walletClient.writeContract({
+            address: nftContract,
+            abi: ERC1155_ABI,
+            functionName: 'setApprovalForAll',
+            args: [approvalTarget, true]
+          })
+        } else {
+          approveTx = await walletClient.writeContract({
+            address: nftContract,
+            abi: ERC721_ABI,
+            functionName: 'setApprovalForAll',
+            args: [approvalTarget, true]
+          })
+        }
+        
+        await this.waitForTransaction(approveTx)
+      }
+    } else {
+      // Original NFTExchange approval logic
+      const isApproved = await checkNFTApproval(nftContract, tokenId, account, isERC1155)
       
-      const approveTx = await this.sendTransaction(userAddress, nftContract, approveData)
-      console.log('NFT approval tx:', approveTx)
-      
-      // Wait for approval to be mined
-      await this.waitForTransaction(approveTx)
+      if (!isApproved) {
+        let approveData
+        if (isERC1155) {
+          approveData = encodeERC1155.setApprovalForAll(ADDRESSES.NFT_EXCHANGE, true)
+        } else {
+          approveData = encodeERC721.approve(ADDRESSES.NFT_EXCHANGE, tokenId)
+        }
+        
+        const approveTx = await this.sendTransaction(account, nftContract, approveData)
+        await this.waitForTransaction(approveTx)
+      }
     }
 
-    // Accept the offer
-    console.log('Accepting offer...')
-    const acceptData = encodeNFTExchange.acceptOffer(offerId)
-    const acceptTx = await this.sendTransaction(userAddress, ADDRESSES.NFT_EXCHANGE, acceptData)
-    console.log('Accept offer tx:', acceptTx)
-
-    return acceptTx
+    const result = await adapter.acceptOffer(offer.id || offer)
+    return result.hash
   }
 
   /**
    * Cancel an offer
    */
-  async cancelOffer(offerId) {
+  async cancelOffer(offerId, contractType = 'nftexchange') {
+    if (contractType === 'seaport') {
+      // Seaport uses cancelListing for offers too
+      return this.cancelListing(offerId, 'seaport')
+    }
+    
     const userAddress = await this.getWalletAddress()
     const cancelData = encodeNFTExchange.cancelOffer(offerId)
     return await this.sendTransaction(userAddress, ADDRESSES.NFT_EXCHANGE, cancelData)


### PR DESCRIPTION
- Update create-listing component to always use Seaport for new listings
- Add marketplace adapter pattern with NFTExchangeAdapter and SeaportAdapter
- Update transaction utilities to route to correct adapter based on contract type
- Add Seaport configuration with contract addresses and helper functions
- Update listing-details component to handle both NFTExchange and Seaport orders
- Ensure all blockchain interactions go through Farcaster Frame ethProvider
- Install @opensea/seaport-js dependency

This implementation maintains backward compatibility with existing NFTExchange listings while routing all new listings through Seaport protocol.